### PR TITLE
[DM-15639] Getting squash metrics into Honeycomb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # squash-honeycomb
 Getting SQuaSH metrics into Honeycomb
+
+1. Clone this repo
+
+```
+git clone https://github.com/lsst-sqre/squash-honeycomb.git
+```
+
+2. Create a virtualenv
+
+```
+cd squash-honeycomb
+
+virtualenv squash-honeycomb -p python3
+source squash-honeycomb/bin/activate
+pip install -r requirements.txt
+```
+
+3. Using the virtualenv in the Jupyter notebook
+
+```
+python -m ipykernel install --user --name=squash-honeycomb
+jupyter notebook
+```
+
+(You should now see your kernel in the Jupyter notebook menu: `Kernel -> Change kernel` and be able so switch to it.)
+
+Open the `squash-honeycomb.ipynb` notebook.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+jupyter>=1.0.0
+libhoney<2.0
+

--- a/squash-honeycomb.ipynb
+++ b/squash-honeycomb.ipynb
@@ -1,0 +1,381 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# [Honeycomb](https://www.honeycomb.io/)\n",
+    "Fast exploration over high cardinality data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting started\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check the [quick start tutorial](https://docs.honeycomb.io/quick-start) to learn about Honeycomb UI capabilities. \n",
+    "Then join the LSST SQuaRE team using [this invitation](https://ui.honeycomb.io/join_team/lsst-square), the datasets created in this notebook are shared with the team.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What is observability?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Honeycomb [observability manifesto](https://www.honeycomb.io/blog/2018/03/observability-a-manifesto/) is a good place to start. Also check the introduction to observability [here](https://docs.honeycomb.io/thinking-about-observability/intro-to-observability/)\n",
+    "\n",
+    "NOTE: KPMs are high level metrics, they are not the kind of 'value' that one would want for observability. However,\n",
+    "in this notebook we'll send KPMs to Honeycomb just because KPMs are the only data that we have in SQuaSH so far. That's still useful to illustrate the use of `libhoney` and `beeline-python` integrations.\n",
+    "\n",
+    "In my opinion, the benefit of this tool will become clearer by sending more *context data* from our DM pipeline tasks, and ultimately as an analysis tool for the Engineer Facility Database (EFD). \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Events and Datasets\n",
+    "Honeycomb data is a series of **Events**, each of which represents something in your environment worth tracking. When you send events to Honeycomb, you collect related or recurring events under a single **Dataset**.\n",
+    "\n",
+    "An **Event** can be anything:\n",
+    "\n",
+    "- an HTTP request to your app\n",
+    "- An SQL query\n",
+    "- A job is submitted to a queue\n",
+    "- An execution of a LSST DM pipeline task\n",
+    "- A detection of particular astronomical object \n",
+    "\n",
+    "**Datasets** are used to partition your data into separate and queryable sets. See [best practices for defining datasets](https://docs.honeycomb.io/getting-data-in/datasets/best-practices/) in Honeycomb. \n",
+    "\n",
+    "Let's start by identifying a `validate_drp` run as our event and creating a new dataset for the metrics measured by each run. \n",
+    "\n",
+    "For illustration purposes we'll collect those metrics from the SQuaSH API:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SQUASH_API_URL = \"https://squash-restful-api-demo.lsst.codes/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "r = requests.get(SQUASH_API_URL + \"/job/1\").json()\n",
+    "    \n",
+    "    \n",
+    "data = {'id': r['id'],\n",
+    "        'date_created': r['date_created'],\n",
+    "        'filter_name': r['meta']['filter_name'],\n",
+    "        'dataset': r['ci_dataset']}\n",
+    "            \n",
+    "# events should be flat dict\n",
+    "for meas in r['measurements']:\n",
+    "    data[meas['metric']] = meas['value']\n",
+    "    \n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This looks like an structured log entry, it also looks like a property set or it may recall something else..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sending events to Honeycomb\n",
+    "\n",
+    "1. When honeycomb gets a request to add an event to a dataset that doesn't exist yet, it creates the dataset.\n",
+    "2. The dataset schema is inferred automatically. It also will infer automatically if you add new fields to your events.\n",
+    "\n",
+    "3. Events are added to the dataset for querying.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NOTE: In order to execute this cell you will need the HONEY_API_KEY. It is avaibale from \"Team Settings\" in the UI once you join the `lsst-square` team."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import libhoney\n",
+    "\n",
+    "HONEY_API_KEY = \"a0a096995745e819bd0169ea6b397c47\"  # Obtained from the UI under \"Team Settings\"\n",
+    "\n",
+    "libhoney.init(writekey=HONEY_API_KEY, dataset=\"single-event-demo\")\n",
+    "libhoney.send_now(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That's it! Check the new dataset at https://ui.honeycomb.io/lsst-square/datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NOTE: this demo dataset may already exist from previous executions of this notebook. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Now, let's send all squash data to Honeycomb\n",
+    "Actually, just the scalar metrics and some context information."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create the `squash-demo` dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "libhoney.init(writekey=HONEY_API_KEY, dataset=\"squash-demo\")\n",
+    "builder = libhoney.Builder()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And loop over all jobs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "    \n",
+    "jobs = requests.get(SQUASH_API_URL + \"/jobs\").json()\n",
+    "\n",
+    "for job_id in jobs['ids']:\n",
+    "\n",
+    "    r = requests.get(SQUASH_API_URL + \"/job/{}\".format(job_id)).json()\n",
+    "    \n",
+    "    if r['ci_dataset'] == 'unknown' or r['ci_dataset'] == 'decam':\n",
+    "        continue\n",
+    "    \n",
+    "    print('Sending event for job {}...'.format(job_id))\n",
+    "\n",
+    "    \n",
+    "    # Spawn a new event and override the timestamp\n",
+    "    event = builder.new_event()\n",
+    "    event.add_field('id', job_id)\n",
+    "    event.add_field('filter_name', r['meta']['filter_name'])\n",
+    "    event.add_field('dataset', r['ci_dataset'])\n",
+    "    \n",
+    "    for meas in r['measurements']:\n",
+    "        event.add_field(meas['metric'], meas['value'])\n",
+    "    \n",
+    "    event.created_at = datetime.strptime(r['date_created'], \"%Y-%m-%dT%H:%M:%SZ\")\n",
+    "    \n",
+    "    event.send()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Querying the dataset\n",
+    "\n",
+    "Querying a Honeycomb dataset in a particular way will produce a series of events (or a time series). The query builder is great tool for fast exploration from the Honeycomb UI. It is also possible to [specify queries programatically](https://docs.honeycomb.io/api/query-specification/)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The SQuaSH `validate_drp.AM1` metric on a given dataset and filter can be obtained obtained from this query:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = {\n",
+    "    \"breakdowns\": [\n",
+    "        \"dataset\", \"filter_name\"\n",
+    "    ],\n",
+    "    \"calculations\": [\n",
+    "        {\"column\": \"validate_drp.AM1\", \"op\": \"AVG\"}\n",
+    "    ],\n",
+    "    \"filters\":[\n",
+    "      {\"column\": \"dataset\", \"op\": \"=\", \"value\": \"validation_data_hsc\"},\n",
+    "      {\"column\": \"filter_name\", \"op\": \"=\", \"value\": \"HSC-R\"}\n",
+    "    ],\n",
+    "    \"filter_combination\": \"AND\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Markers\n",
+    "Markers are annotations over the time series plot. Markers are defined per dataset and can be created programatically via the [Markers API](https://docs.honeycomb.io/api/markers/).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "headers = {'X-Honeycomb-Team': HONEY_API_KEY}\n",
+    "\n",
+    "marker={\"message\": \"Testing marker API\"}\n",
+    "\n",
+    "r = requests.post(\"https://api.honeycomb.io/1/markers/squash-demo\", json=marker, headers=headers)\n",
+    "r.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All the Markers in a dataset may be retrieved by:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = requests.get(\"https://api.honeycomb.io/1/markers/squash-demo\", headers=headers)\n",
+    "r.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Triggers\n",
+    "\n",
+    "Given a time series and a threshold one can use the [Triggers API](https://docs.honeycomb.io/api/triggers/) for setting alerts when the values pass a threshold. Triggers are also defined per dataset. Honeycomb provides integration with Slack for alert notification. \n",
+    "\n",
+    "Let's set an alert for the `validate_drp.AM1` metric. We'll get the design specification for that metric from the SQuaSH API:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spec = requests.get(SQUASH_API_URL + \"spec/validate_drp.AM1.design\" ).json()\n",
+    "spec"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trigger = {\"name\": \"AM1 alert\",\n",
+    "           \"query\": query,\n",
+    "           \"threshold\": {\"op\": spec[\"threshold\"][\"operator\"], \n",
+    "                         \"value\": spec[\"threshold\"][\"value\"]},\n",
+    "           \"frequency\": 1800\n",
+    "          }\n",
+    "trigger"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = requests.post(\"https://api.honeycomb.io/1/triggers/squash-demo\", json=trigger, headers=headers)\n",
+    "r"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finnaly, all Triggers in a dataset may be retrieved by:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = requests.get(\"https://api.honeycomb.io/1/triggers/squash-demo\", headers=headers)\n",
+    "r.json()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "honeycomb",
+   "language": "python",
+   "name": "honeycomb"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/squash-honeycomb.ipynb
+++ b/squash-honeycomb.ipynb
@@ -131,7 +131,7 @@
    "source": [
     "import libhoney\n",
     "\n",
-    "HONEY_API_KEY = \"a0a096995745e819bd0169ea6b397c47\"  # Obtained from the UI under \"Team Settings\"\n",
+    "HONEY_API_KEY = \"\"  # Obtained from the UI under \"Team Settings\"\n",
     "\n",
     "libhoney.init(writekey=HONEY_API_KEY, dataset=\"single-event-demo\")\n",
     "libhoney.send_now(data)"

--- a/squash-honeycomb.ipynb
+++ b/squash-honeycomb.ipynb
@@ -35,12 +35,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Honeycomb [observability manifesto](https://www.honeycomb.io/blog/2018/03/observability-a-manifesto/) is a good place to start. Also check the introduction to observability [here](https://docs.honeycomb.io/thinking-about-observability/intro-to-observability/)\n",
+    "The Honeycomb [observability manifesto](https://www.honeycomb.io/blog/2018/03/observability-a-manifesto/) is a good place to start. Also check the introduction to observability [here](https://docs.honeycomb.io/thinking-about-observability/intro-to-observability/).\n",
     "\n",
     "NOTE: KPMs are high level metrics, they are not the kind of 'value' that one would want for observability. However,\n",
     "in this notebook we'll send KPMs to Honeycomb just because KPMs are the only data that we have in SQuaSH so far. That's still useful to illustrate the use of `libhoney` and `beeline-python` integrations.\n",
     "\n",
-    "In my opinion, the benefit of this tool will become clearer by sending more *context data* from our DM pipeline tasks, and ultimately as an analysis tool for the Engineer Facility Database (EFD). \n"
+    "In my opinion, the benefit of this tool will become clearer by sending more *context data* from our DM pipeline tasks, and ultimately as an analysis tool for the Engineering and Facilities Database (EFD). \n"
    ]
   },
   {
@@ -60,7 +60,7 @@
     "\n",
     "**Datasets** are used to partition your data into separate and queryable sets. See [best practices for defining datasets](https://docs.honeycomb.io/getting-data-in/datasets/best-practices/) in Honeycomb. \n",
     "\n",
-    "Let's start by identifying a `validate_drp` run as our event and creating a new dataset for the metrics measured by each run. \n",
+    "Let's start by identifying a `validate_drp` run as the `Event` containing the metrics measured by each run. \n",
     "\n",
     "For illustration purposes we'll collect those metrics from the SQuaSH API:"
    ]
@@ -112,8 +112,7 @@
     "1. When honeycomb gets a request to add an event to a dataset that doesn't exist yet, it creates the dataset.\n",
     "2. The dataset schema is inferred automatically. It also will infer automatically if you add new fields to your events.\n",
     "\n",
-    "3. Events are added to the dataset for querying.\n",
-    "\n"
+    "3. Events are added to the dataset for querying."
    ]
   },
   {
@@ -148,7 +147,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "NOTE: this demo dataset may already exist from previous executions of this notebook. "
+    "NOTE: this demo dataset may already exist from previous executions of this notebook, make sure you delete it before running the notebook if you want to start from an empty dataset. If you don't, note that as long as events have different timestamps they will be inserted in the existing dataset."
    ]
   },
   {
@@ -163,7 +162,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create the `squash-demo` dataset"
+    "Create the `squash-demo` dataset:"
    ]
   },
   {
@@ -180,7 +179,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And loop over all jobs:"
+    "Now loop over all jobs:"
    ]
   },
   {
@@ -230,7 +229,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The SQuaSH `validate_drp.AM1` metric on a given dataset and filter can be obtained obtained from this query:"
+    "The SQuaSH `validate_drp.AM1` metric on a given dataset and filter can be obtained from this query:"
    ]
   },
   {
@@ -315,6 +314,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the operator in the `lsst.verify` specifications is such that \"measurement `op` spec\" is True if the measurement passes the specification. But we need the oposit when configuring alerts. In ordert to do that we created this mapping: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inverse_operation = { '==': '!=', '!=': '==', '>': '<', '>=': '<=', '<': '>', '<=': '>='}"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -322,7 +337,7 @@
    "source": [
     "trigger = {\"name\": \"AM1 alert\",\n",
     "           \"query\": query,\n",
-    "           \"threshold\": {\"op\": spec[\"threshold\"][\"operator\"], \n",
+    "           \"threshold\": {\"op\": inverse_operation[spec[\"threshold\"][\"operator\"]], \n",
     "                         \"value\": spec[\"threshold\"][\"value\"]},\n",
     "           \"frequency\": 1800\n",
     "          }\n",


### PR DESCRIPTION
- Presents the main concepts of the Honeycomb
- Illustrates an workflow where metrics values are collected, stored in SQuaSH and sent to Honeycomb for analysis
- In particular it creates a `squash-demo` dataset for the SQuaSH metrics, and uses `liboney` to send those metrics to Honeycomb, it shows how to use the Markers API for plot annotations and the Triggers API for configuring alerts based on metric specs obtained from the SQuaSH API.
