### PR TITLE
minor corrections and some additions

### DIFF
--- a/squash-honeycomb.ipynb
+++ b/squash-honeycomb.ipynb
@@ -119,7 +119,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "NOTE: In order to execute this cell you will need the HONEY_API_KEY. It is avaibale from \"Team Settings\" in the UI once you join the `lsst-square` team."
+    "NOTE: In order to execute this cell you will need the HONEY_API_KEY. It is available from \"Team Settings\" in the UI once you join the `lsst-square` team."
    ]
   },
   {
@@ -147,7 +147,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "NOTE: this demo dataset may already exist from previous executions of this notebook, make sure you delete it before running the notebook if you want to start from an empty dataset. If you don't, note that as long as events have different timestamps they will be inserted in the existing dataset."
+    "NOTE: this demo dataset may already exist from previous executions of this notebook, make sure you delete it before running the notebook if you want to start from an empty dataset. If you don't, note that they will be inserted in the existing dataset."
    ]
   },
   {
@@ -258,7 +258,7 @@
    "metadata": {},
    "source": [
     "## Markers\n",
-    "Markers are annotations over the time series plot. Markers are defined per dataset and can be created programatically via the [Markers API](https://docs.honeycomb.io/api/markers/).\n"
+    "Markers are annotations over the time series plot. Markers are defined per dataset and can be created programatically via the [UI, a CLI](https://docs.honeycomb.io/working-with-data/markers/), or the [Markers API](https://docs.honeycomb.io/api/markers/).\n"
    ]
   },
   {
@@ -317,7 +317,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the operator in the `lsst.verify` specifications is such that \"measurement `op` spec\" is True if the measurement passes the specification. But we need the oposit when configuring alerts. In ordert to do that we created this mapping: "
+    "Note that the operator in the `lsst.verify` specifications is such that \"measurement `op` spec\" is True if the measurement passes the specification. But we need the opposite when configuring alerts. In order to do that we created this mapping: "
    ]
   },
   {
@@ -326,10 +326,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inverse_operation = { '==': '!=', '!=': '==', '>': '<', '>=': '<=', '<': '>', '<=': '>='}"
+    "inverse_operation = { '>': '<=', '>=': '<', '<': '>=', '<=': '>'}"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also note that triggers do not support equality and inequality, so if converting a `lsst.verify` spec to a Honeycomb trigger and the spec uses an equality match, you will have to decide whether the appropriate trigger comparison is greater than or less than the value."
+   ]
+  },  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
I noticed a few typos and some small inaccuracies in this amazing doc. 

Some explanation on the non-typo changes:

* Honeycomb will accept events with the same time stamp; they will be represented as two events at the same time.  I removed the text "...as long as events have different timestamps..." to reflect this. Sending the same data in to Honeycomb will have the effect of artificially inflating things like `COUNT` for the duplicate events, but they will be happily accepted.

* I removed the equality comparisons from the list of changes to use when making a Trigger. Most measurements that can become triggers are as well served by a less than or greater than comparison as they are an inequality comparison. In the rare case that you really need both sides of an equality match, you'll need to create two triggers. 

* More interestingly though (still in the Trigger section), I changed the greater than / less than pairing - the opposite of `>` is `<=` rather than `<` in order to keep the decision at the threshold point the same. 

Thanks for writing this up and considering my change.